### PR TITLE
Api/feature/87

### DIFF
--- a/src/main/java/com/squadb/workassistantapi/member/dto/LoginMember.java
+++ b/src/main/java/com/squadb/workassistantapi/member/dto/LoginMember.java
@@ -1,7 +1,6 @@
 package com.squadb.workassistantapi.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.squadb.workassistantapi.member.domain.Member;
 import com.squadb.workassistantapi.member.domain.MemberType;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
@@ -20,9 +19,4 @@ public class LoginMember implements Serializable {
 
     @JsonIgnore
     public boolean isAdmin() { return type.isAdmin(); }
-
-    @JsonIgnore
-    public boolean is(Member member) {
-        return member != null && member.getId() == this.id;
-    }
 }

--- a/src/main/java/com/squadb/workassistantapi/rental/application/RentalService.java
+++ b/src/main/java/com/squadb/workassistantapi/rental/application/RentalService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static java.time.LocalDateTime.now;
@@ -62,6 +63,8 @@ public class RentalService {
             log.warn("존재하지 않는 대여 목록 입니다. {}", rentalIdList);
             return;
         }
-        rentalList.forEach(rental -> rental.returnBy(loginMember));
+        final Member member = memberService.findById(loginMember.getId());
+        final LocalDateTime returnDate = now();
+        rentalList.forEach(rental -> rental.returnBy(member, returnDate));
     }
 }

--- a/src/main/java/com/squadb/workassistantapi/rental/domain/Rental.java
+++ b/src/main/java/com/squadb/workassistantapi/rental/domain/Rental.java
@@ -43,6 +43,7 @@ public class Rental {
     private LocalDateTime endDate;
 
     @Column
+    @Getter(AccessLevel.PACKAGE)
     private LocalDateTime returnDate;
 
     @Getter
@@ -98,6 +99,15 @@ public class Rental {
         this.status = RETURN;
         this.book.increaseStock();
         this.returnDate = LocalDateTime.now();
+    }
+
+    public void returnBy(Member member, LocalDateTime returnDate) {
+        if (!member.isAdmin() && !member.equals(this.member)) {
+            throw new NoAuthorizationException("관리자 또는 책의 대여자만 책 반납이 가능합니다.");
+        }
+        this.status = RETURN;
+        this.book.increaseStock();
+        this.returnDate = returnDate;
     }
 
     public boolean isReturned() {

--- a/src/main/java/com/squadb/workassistantapi/rental/domain/Rental.java
+++ b/src/main/java/com/squadb/workassistantapi/rental/domain/Rental.java
@@ -2,7 +2,6 @@ package com.squadb.workassistantapi.rental.domain;
 
 import com.squadb.workassistantapi.book.domain.Book;
 import com.squadb.workassistantapi.member.domain.Member;
-import com.squadb.workassistantapi.member.dto.LoginMember;
 import com.squadb.workassistantapi.reservation.domain.ReservationFinisher;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -90,15 +89,6 @@ public class Rental {
 
     public String getBookTitle() {
         return book.getTitle();
-    }
-
-    public void returnBy(LoginMember loginMember) {
-        if (!loginMember.isAdmin() && loginMember.is(member)) {
-            throw new NoAuthorizationException("반납할 권한이 없습니다.");
-        }
-        this.status = RETURN;
-        this.book.increaseStock();
-        this.returnDate = LocalDateTime.now();
     }
 
     public void returnBy(Member member, LocalDateTime returnDate) {

--- a/src/test/java/com/squadb/workassistantapi/book/domain/BookTest.java
+++ b/src/test/java/com/squadb/workassistantapi/book/domain/BookTest.java
@@ -7,7 +7,7 @@ import java.time.LocalDateTime;
 
 import static com.squadb.workassistantapi.book.domain.IsbnTest.isbn;
 import static com.squadb.workassistantapi.member.domain.MemberTest.관리자;
-import static com.squadb.workassistantapi.member.domain.MemberTest.일반회원;
+import static com.squadb.workassistantapi.member.domain.MemberTest.일반회원1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -22,7 +22,7 @@ class BookTest {
                 .title("Spring")
                 .stockQuantity(StockQuantity.valueOf(1))
                 .registrationDate(LocalDateTime.now())
-                .registrant(일반회원)
+                .registrant(일반회원1)
                 .build());
     }
 

--- a/src/test/java/com/squadb/workassistantapi/member/domain/MemberTest.java
+++ b/src/test/java/com/squadb/workassistantapi/member/domain/MemberTest.java
@@ -11,7 +11,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class MemberTest {
     public static final Member 관리자 = createMember("admin@miridih.com", "관리자", "1234", ADMIN);
-    public static final Member 일반회원 = createMember("normal@miridih.com", "김일반", "1234", NORMAL);
+    public static final Member 일반회원1 = createMember("normal@miridih.com", "김일반", "1234", NORMAL);
+    public static final Member 일반회원2 = createMember("normal2@miridih.com", "박일반", "1234", NORMAL);
 
     @DisplayName("회원은 비밀번호를 검사할 수 있다.")
     @Test
@@ -30,7 +31,7 @@ public class MemberTest {
         };
 
         // when //then
-        assertThatThrownBy(() -> 일반회원.checkEqualPassword("wrong password", wrongPasswordEncryptor))
+        assertThatThrownBy(() -> 일반회원1.checkEqualPassword("wrong password", wrongPasswordEncryptor))
                 .isInstanceOf(LoginFailedException.class);
     }
 

--- a/src/test/java/com/squadb/workassistantapi/rental/domain/RentalTest.java
+++ b/src/test/java/com/squadb/workassistantapi/rental/domain/RentalTest.java
@@ -10,15 +10,18 @@ import org.junit.jupiter.api.Test;
 import java.time.LocalDateTime;
 
 import static com.squadb.workassistantapi.book.domain.IsbnTest.isbn;
-import static com.squadb.workassistantapi.member.domain.MemberTest.관리자;
-import static com.squadb.workassistantapi.member.domain.MemberTest.일반회원1;
+import static com.squadb.workassistantapi.member.domain.MemberTest.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 class RentalTest {
 
+    private static final int INITIAL_BOOK_STOCK = 2;
+
     private Rental rental;
     private Book book;
+    private LocalDateTime returnDate;
 
     @BeforeEach
     void setUp() {
@@ -26,55 +29,82 @@ class RentalTest {
                 .registrant(관리자)
                 .title("JPA")
                 .isbn(isbn)
-                .stockQuantity(StockQuantity.valueOf(2))
+                .stockQuantity(StockQuantity.valueOf(INITIAL_BOOK_STOCK))
                 .registrationDate(LocalDateTime.now())
                 .build();
-
-        final LocalDateTime rentalStartDate = LocalDateTime.now();
-
-        rental = Rental.createRental(book, 일반회원1, false, rentalStartDate, mock(RentalValidator.class), mock(ReservationFinisher.class));
+        rental = Rental.createRental(book, 일반회원1, false, LocalDateTime.now(), mock(RentalValidator.class), mock(ReservationFinisher.class));
+        returnDate = LocalDateTime.now();
     }
 
     @DisplayName("책 대여시 책의 재고가 하나 줄어야 한다.")
     @Test
     void createRentalTest() {
         // then
-        assertThat(book.getStockQuantity()).isEqualTo(StockQuantity.valueOf(1));
+        assertThat(book.getStockQuantity()).isEqualTo(StockQuantity.valueOf(INITIAL_BOOK_STOCK - 1));
     }
 
     @DisplayName("일반회원은 자신이 빌린 책을 반납할 수 있다.")
     @Test
     void normalMemberBookReturnTest() {
+        // when
+        rental.returnBy(일반회원1, returnDate);
 
-    }
-
-    @DisplayName("일반회원은 다른사람이 빌린 책을 반납할 수 없다.")
-    @Test
-    void normalMemberBookReturnFailTest() {
-
+        // then
+        verifySuccessReturnBook();
     }
 
     @DisplayName("관리자는 다른사람이 빌린 책도 반납할 수 있다.")
     @Test
     void adminMemberBookReturnTest() {
+        // when
+        rental.returnBy(관리자, returnDate);
 
+        // then
+        verifySuccessReturnBook();
+    }
+
+    private void verifySuccessReturnBook() {
+        assertThat(rental.isReturned()).isTrue();
+        assertThat(book.getStockQuantity()).isEqualTo(StockQuantity.valueOf(INITIAL_BOOK_STOCK));
+        assertThat(rental.getReturnDate()).isEqualTo(returnDate);
+    }
+
+    @DisplayName("일반회원은 다른사람이 빌린 책을 반납할 수 없다.")
+    @Test
+    void normalMemberBookReturnFailTest() {
+        // when then
+        assertThatThrownBy(() -> rental.returnBy(일반회원2, returnDate))
+                .isInstanceOf(NoAuthorizationException.class)
+                .hasMessageContaining("관리자 또는 책의 대여자만 책 반납이 가능합니다.");
     }
 
     @DisplayName("책을 반납하면 대여는 RETURN 상태가 된다.")
     @Test
     void returnStatusTest() {
+        // when
+        rental.returnBy(일반회원1, returnDate);
 
+        // then
+        assertThat(rental.isReturned()).isTrue();
     }
 
     @DisplayName("책을 반납하면 책의 재고가 하나 늘어나야 한다.")
     @Test
     void increaseBookStockTest() {
+        // when
+        rental.returnBy(일반회원1, returnDate);
 
+        // then
+        assertThat(book.getStockQuantity()).isEqualTo(StockQuantity.valueOf(INITIAL_BOOK_STOCK));
     }
 
     @DisplayName("책을 반납하면 반납한 시간이 기록된다.")
     @Test
     void recordReturnDateTest() {
+        // when
+        rental.returnBy(일반회원1, returnDate);
 
+        // then
+        assertThat(rental.getReturnDate()).isEqualTo(returnDate);
     }
 }

--- a/src/test/java/com/squadb/workassistantapi/rental/domain/RentalTest.java
+++ b/src/test/java/com/squadb/workassistantapi/rental/domain/RentalTest.java
@@ -3,6 +3,7 @@ package com.squadb.workassistantapi.rental.domain;
 import com.squadb.workassistantapi.book.domain.Book;
 import com.squadb.workassistantapi.book.domain.StockQuantity;
 import com.squadb.workassistantapi.reservation.domain.ReservationFinisher;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -10,30 +11,70 @@ import java.time.LocalDateTime;
 
 import static com.squadb.workassistantapi.book.domain.IsbnTest.isbn;
 import static com.squadb.workassistantapi.member.domain.MemberTest.관리자;
-import static com.squadb.workassistantapi.member.domain.MemberTest.일반회원;
+import static com.squadb.workassistantapi.member.domain.MemberTest.일반회원1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 class RentalTest {
 
-    @DisplayName("책 대여시 책의 재고가 하나 줄어야 한다.")
-    @Test
-    void createRentalTest() {
-        // given
-        final Book springBook = Book.builder()
+    private Rental rental;
+    private Book book;
+
+    @BeforeEach
+    void setUp() {
+        book = Book.builder()
                 .registrant(관리자)
                 .title("JPA")
                 .isbn(isbn)
                 .stockQuantity(StockQuantity.valueOf(2))
                 .registrationDate(LocalDateTime.now())
                 .build();
+
         final LocalDateTime rentalStartDate = LocalDateTime.now();
 
-        // when
-        Rental.createRental(springBook, 일반회원, false, rentalStartDate, mock(RentalValidator.class), mock(ReservationFinisher.class));
-
-        // then
-        assertThat(springBook.getStockQuantity()).isEqualTo(StockQuantity.valueOf(1));
+        rental = Rental.createRental(book, 일반회원1, false, rentalStartDate, mock(RentalValidator.class), mock(ReservationFinisher.class));
     }
 
+    @DisplayName("책 대여시 책의 재고가 하나 줄어야 한다.")
+    @Test
+    void createRentalTest() {
+        // then
+        assertThat(book.getStockQuantity()).isEqualTo(StockQuantity.valueOf(1));
+    }
+
+    @DisplayName("일반회원은 자신이 빌린 책을 반납할 수 있다.")
+    @Test
+    void normalMemberBookReturnTest() {
+
+    }
+
+    @DisplayName("일반회원은 다른사람이 빌린 책을 반납할 수 없다.")
+    @Test
+    void normalMemberBookReturnFailTest() {
+
+    }
+
+    @DisplayName("관리자는 다른사람이 빌린 책도 반납할 수 있다.")
+    @Test
+    void adminMemberBookReturnTest() {
+
+    }
+
+    @DisplayName("책을 반납하면 대여는 RETURN 상태가 된다.")
+    @Test
+    void returnStatusTest() {
+
+    }
+
+    @DisplayName("책을 반납하면 책의 재고가 하나 늘어나야 한다.")
+    @Test
+    void increaseBookStockTest() {
+
+    }
+
+    @DisplayName("책을 반납하면 반납한 시간이 기록된다.")
+    @Test
+    void recordReturnDateTest() {
+
+    }
 }


### PR DESCRIPTION
* 책 반납시  테스트 코드를 추가
* domain 인 Renal 클래스에서 DTO 인 LoginMember 에 대한 의존성을 제거

작업을 했습니다.

그런데 책 반납 단위테스트 짜면서 고민 됐던 것이 있습니다.

'회원은 자신이 빌린 책을 반납할 수 있다' 와 같은 전체적인 반납 성공 테스트가 있고

'책을 반납하면 책의 재고가 하나 늘어나야 한다.' 와 같은 부분적인 반납 테스트가 있는데요

```assertThat(book.getStockQuantity()).isEqualTo(StockQuantity.valueOf(INITIAL_BOOK_STOCK))```
이 코드는 두 테스트 공통으로 필요한 코드라고 생각이 됩니다.
이 라인을 한 줄 짜리 private 메서드로 뺄지 , 그냥 지금 한 것처럼 assert 문을 중복으로 넣어야 할지 고민이었습니다. 

지금 상태에서는 한줄 짜리 private 메서드로 빼면 오히려 코드량이 더 많아져 assert 문을 중복으로 넣었습니다.
(assertThat(book.getStockQuantity()).isEqualTo(StockQuantity.valueOf(INITIAL_BOOK_STOCK)) 
이 코드가  '회원은 자신이 빌린 책을 반납할 수 있다' 테스트에도 들어가고, '책을 반납하면 책의 재고가 하나 늘어나야 한다.' 테스트에도 들어간다는 말)

하지만 이렇게 될 경우에 book.getStockQuantity() 의 리턴값이 달라지거나 하면 두 개의 테스트를 수정해줘야 하는 단점도 있습니다.
혹시 좋은 방법 있을까요?
